### PR TITLE
Add three-view presentation editor with drag-drop reordering

### DIFF
--- a/app/components/editor/DetailView.tsx
+++ b/app/components/editor/DetailView.tsx
@@ -1,0 +1,266 @@
+import React from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  IconButton,
+  Toolbar,
+  Divider,
+  Chip,
+  Zoom,
+  Fade,
+} from '@mui/material';
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
+import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+// Simplified slide interface for the editor
+interface SimpleSlide {
+  id: string;
+  type: string;
+  title?: string;
+  subtitle?: string;
+  content?: string;
+  imageUrl?: string;
+  order: number;
+}
+
+interface DetailViewProps {
+  slides: SimpleSlide[];
+  currentSlideIndex: number;
+  onNavigate: (index: number) => void;
+  onEditSlide: (slideId: string) => void;
+  onDeleteSlide: (slideId: string) => void;
+  onDuplicateSlide: (slideId: string) => void;
+}
+
+export const DetailView: React.FC<DetailViewProps> = ({
+  slides,
+  currentSlideIndex,
+  onNavigate,
+  onEditSlide,
+  onDeleteSlide,
+  onDuplicateSlide,
+}) => {
+  const [isFullscreen, setIsFullscreen] = React.useState(false);
+  const currentSlide = slides[currentSlideIndex];
+
+  const handlePrevious = () => {
+    if (currentSlideIndex > 0) {
+      onNavigate(currentSlideIndex - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentSlideIndex < slides.length - 1) {
+      onNavigate(currentSlideIndex + 1);
+    }
+  };
+
+  const handleKeyPress = React.useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft') {
+        handlePrevious();
+      } else if (event.key === 'ArrowRight') {
+        handleNext();
+      } else if (event.key === 'f' || event.key === 'F') {
+        setIsFullscreen(!isFullscreen);
+      }
+    },
+    [currentSlideIndex, isFullscreen]
+  );
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleKeyPress);
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [handleKeyPress]);
+
+  if (!currentSlide) {
+    return (
+      <Paper sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <Typography variant="h6" color="text.secondary">
+          No slide selected
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }}>
+      {!isFullscreen && (
+        <Toolbar sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Typography variant="h6" sx={{ flex: 1 }}>
+            Slide {currentSlideIndex + 1} of {slides.length}
+          </Typography>
+          <Chip
+            label={currentSlide.type}
+            size="small"
+            sx={{ mr: 2 }}
+          />
+          <IconButton onClick={() => onEditSlide(currentSlide.id)} size="small">
+            <EditIcon />
+          </IconButton>
+          <IconButton onClick={() => onDuplicateSlide(currentSlide.id)} size="small">
+            <ContentCopyIcon />
+          </IconButton>
+          <IconButton onClick={() => onDeleteSlide(currentSlide.id)} size="small">
+            <DeleteIcon />
+          </IconButton>
+          <Divider orientation="vertical" flexItem sx={{ mx: 1 }} />
+          <IconButton onClick={() => setIsFullscreen(true)} size="small">
+            <FullscreenIcon />
+          </IconButton>
+        </Toolbar>
+      )}
+
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          p: isFullscreen ? 0 : 4,
+          bgcolor: isFullscreen ? 'black' : 'grey.50',
+          position: 'relative',
+        }}
+      >
+        <Fade in key={currentSlide.id}>
+          <Box
+            sx={{
+              width: isFullscreen ? '100%' : '90%',
+              maxWidth: isFullscreen ? '100%' : 1200,
+              height: isFullscreen ? '100%' : 'auto',
+              aspectRatio: isFullscreen ? 'auto' : '16 / 9',
+              bgcolor: 'background.paper',
+              boxShadow: isFullscreen ? 0 : 10,
+              borderRadius: isFullscreen ? 0 : 2,
+              overflow: 'hidden',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Box sx={{ p: 4 }}>
+              <Typography variant="h3" gutterBottom>
+                {currentSlide.title || `Slide ${currentSlideIndex + 1}`}
+              </Typography>
+              {currentSlide.subtitle && (
+                <Typography variant="h5" color="text.secondary" gutterBottom>
+                  {currentSlide.subtitle}
+                </Typography>
+              )}
+              {currentSlide.content && (
+                <Typography variant="body1">
+                  {currentSlide.content}
+                </Typography>
+              )}
+              {currentSlide.imageUrl && (
+                <Box
+                  component="img"
+                  src={currentSlide.imageUrl}
+                  sx={{ width: '100%', maxHeight: 400, objectFit: 'contain', mt: 2 }}
+                />
+              )}
+            </Box>
+          </Box>
+        </Fade>
+
+        <Zoom in>
+          <IconButton
+            onClick={handlePrevious}
+            disabled={currentSlideIndex === 0}
+            sx={{
+              position: 'absolute',
+              left: isFullscreen ? 16 : 32,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              bgcolor: 'background.paper',
+              boxShadow: 2,
+              '&:hover': { bgcolor: 'background.paper' },
+            }}
+          >
+            <NavigateBeforeIcon fontSize="large" />
+          </IconButton>
+        </Zoom>
+
+        <Zoom in>
+          <IconButton
+            onClick={handleNext}
+            disabled={currentSlideIndex === slides.length - 1}
+            sx={{
+              position: 'absolute',
+              right: isFullscreen ? 16 : 32,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              bgcolor: 'background.paper',
+              boxShadow: 2,
+              '&:hover': { bgcolor: 'background.paper' },
+            }}
+          >
+            <NavigateNextIcon fontSize="large" />
+          </IconButton>
+        </Zoom>
+
+        {isFullscreen && (
+          <Zoom in>
+            <IconButton
+              onClick={() => setIsFullscreen(false)}
+              sx={{
+                position: 'absolute',
+                top: 16,
+                right: 16,
+                bgcolor: 'background.paper',
+                boxShadow: 2,
+                '&:hover': { bgcolor: 'background.paper' },
+              }}
+            >
+              <FullscreenExitIcon />
+            </IconButton>
+          </Zoom>
+        )}
+
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: isFullscreen ? 16 : 32,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            gap: 1,
+          }}
+        >
+          {slides.map((_, index) => (
+            <Box
+              key={index}
+              onClick={() => onNavigate(index)}
+              sx={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                bgcolor: index === currentSlideIndex ? 'primary.main' : 'grey.400',
+                cursor: 'pointer',
+                transition: 'all 0.2s',
+                '&:hover': {
+                  transform: 'scale(1.5)',
+                },
+              }}
+            />
+          ))}
+        </Box>
+      </Box>
+
+      {!isFullscreen && (
+        <Box sx={{ p: 2, borderTop: 1, borderColor: 'divider', bgcolor: 'grey.50' }}>
+          <Typography variant="body2" color="text.secondary">
+            Use arrow keys to navigate • Press F for fullscreen
+          </Typography>
+        </Box>
+      )}
+    </Paper>
+  );
+};

--- a/app/components/editor/GridView.tsx
+++ b/app/components/editor/GridView.tsx
@@ -1,0 +1,290 @@
+import React, { useState } from 'react';
+import {
+  Grid,
+  Card,
+  CardMedia,
+  CardContent,
+  Typography,
+  Box,
+  Slider,
+  Paper,
+  IconButton,
+  Menu,
+  MenuItem,
+} from '@mui/material';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  rectSortingStrategy,
+} from '@dnd-kit/sortable';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import ViewColumnIcon from '@mui/icons-material/ViewColumn';
+// Simplified slide interface for the editor
+interface SimpleSlide {
+  id: string;
+  type: string;
+  title?: string;
+  subtitle?: string;
+  content?: string;
+  imageUrl?: string;
+  order: number;
+}
+
+interface GridViewProps {
+  slides: SimpleSlide[];
+  onReorder: (slides: SimpleSlide[]) => void;
+  onSelectSlide: (slideId: string) => void;
+  onDeleteSlide: (slideId: string) => void;
+  onDuplicateSlide: (slideId: string) => void;
+  selectedSlideId?: string;
+}
+
+interface SortableCardProps {
+  slide: SimpleSlide;
+  index: number;
+  columns: number;
+  isSelected: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  onDuplicate: () => void;
+}
+
+const SortableCard: React.FC<SortableCardProps> = ({
+  slide,
+  index,
+  columns,
+  isSelected,
+  onSelect,
+  onDelete,
+  onDuplicate,
+}) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: slide.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const getGridColumns = () => {
+    switch (columns) {
+      case 1: return { xs: 12 };
+      case 2: return { xs: 12, sm: 6 };
+      case 3: return { xs: 12, sm: 6, md: 4 };
+      case 4: return { xs: 12, sm: 6, md: 3 };
+      case 5: return { xs: 12, sm: 6, md: 2.4 };
+      case 6: return { xs: 12, sm: 4, md: 2 };
+      default: return { xs: 12, sm: 6, md: 4 };
+    }
+  };
+
+  return (
+    <Grid {...getGridColumns()}>
+      <Card
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        {...listeners}
+        onClick={onSelect}
+        sx={{
+          cursor: isDragging ? 'grabbing' : 'pointer',
+          position: 'relative',
+          border: isSelected ? 2 : 1,
+          borderColor: isSelected ? 'primary.main' : 'divider',
+          transition: 'all 0.2s',
+          '&:hover': {
+            boxShadow: 4,
+            transform: 'translateY(-2px)',
+          },
+        }}
+      >
+        <Box sx={{ position: 'relative', paddingTop: '56.25%', bgcolor: 'grey.100' }}>
+          <Box
+            sx={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: 'background.paper',
+            }}
+          >
+            <Typography variant="h4" color="text.secondary">
+              {index + 1}
+            </Typography>
+          </Box>
+          <IconButton
+            size="small"
+            onClick={handleMenuOpen}
+            sx={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              bgcolor: 'background.paper',
+              '&:hover': { bgcolor: 'background.paper' },
+            }}
+          >
+            <MoreVertIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <CardContent sx={{ py: 1 }}>
+          <Typography variant="body2" noWrap>
+            {slide.title || `Slide ${index + 1}`}
+          </Typography>
+          <Typography variant="caption" color="text.secondary" noWrap>
+            {slide.type}
+          </Typography>
+        </CardContent>
+        <Menu
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={handleMenuClose}
+        >
+          <MenuItem
+            onClick={() => {
+              onDuplicate();
+              handleMenuClose();
+            }}
+          >
+            Duplicate
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              onDelete();
+              handleMenuClose();
+            }}
+          >
+            Delete
+          </MenuItem>
+        </Menu>
+      </Card>
+    </Grid>
+  );
+};
+
+export const GridView: React.FC<GridViewProps> = ({
+  slides,
+  onReorder,
+  onSelectSlide,
+  onDeleteSlide,
+  onDuplicateSlide,
+  selectedSlideId,
+}) => {
+  const [columns, setColumns] = useState(3);
+  
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = slides.findIndex((slide) => slide.id === active.id);
+      const newIndex = slides.findIndex((slide) => slide.id === over.id);
+      const newSlides = arrayMove(slides, oldIndex, newIndex);
+      onReorder(newSlides);
+    }
+  };
+
+  const handleColumnChange = (_: Event, newValue: number | number[]) => {
+    setColumns(newValue as number);
+  };
+
+  return (
+    <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <Box
+        sx={{
+          p: 2,
+          borderBottom: 1,
+          borderColor: 'divider',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+        }}
+      >
+        <Typography variant="h6" sx={{ flex: 1 }}>
+          Grid View
+        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, minWidth: 250 }}>
+          <ViewColumnIcon color="action" />
+          <Slider
+            value={columns}
+            onChange={handleColumnChange}
+            min={1}
+            max={6}
+            marks
+            valueLabelDisplay="auto"
+            sx={{ flex: 1 }}
+          />
+          <Typography variant="body2" sx={{ minWidth: 20 }}>
+            {columns}
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={slides.map(s => s.id)}
+            strategy={rectSortingStrategy}
+          >
+            <Grid container spacing={2}>
+              {slides.map((slide, index) => (
+                <SortableCard
+                  key={slide.id}
+                  slide={slide}
+                  index={index}
+                  columns={columns}
+                  isSelected={selectedSlideId === slide.id}
+                  onSelect={() => onSelectSlide(slide.id)}
+                  onDelete={() => onDeleteSlide(slide.id)}
+                  onDuplicate={() => onDuplicateSlide(slide.id)}
+                />
+              ))}
+            </Grid>
+          </SortableContext>
+        </DndContext>
+      </Box>
+    </Paper>
+  );
+};

--- a/app/components/editor/OutlineView.tsx
+++ b/app/components/editor/OutlineView.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import {
+  List,
+  ListItem,
+  ListItemText,
+  ListItemIcon,
+  IconButton,
+  Typography,
+  Box,
+  Paper,
+} from '@mui/material';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import DeleteIcon from '@mui/icons-material/Delete';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import TextFieldsIcon from '@mui/icons-material/TextFields';
+import ImageIcon from '@mui/icons-material/Image';
+import FormatQuoteIcon from '@mui/icons-material/FormatQuote';
+import { SortableSlideItem } from './SortableSlideItem';
+// Simplified slide interface for the editor
+interface SimpleSlide {
+  id: string;
+  type: string;
+  title?: string;
+  subtitle?: string;
+  content?: string;
+  imageUrl?: string;
+  order: number;
+}
+
+interface OutlineViewProps {
+  slides: SimpleSlide[];
+  onReorder: (slides: SimpleSlide[]) => void;
+  onSelectSlide: (slideId: string) => void;
+  onDeleteSlide: (slideId: string) => void;
+  onDuplicateSlide: (slideId: string) => void;
+  selectedSlideId?: string;
+}
+
+const getSlideIcon = (type: string) => {
+  switch (type) {
+    case 'title':
+    case 'content':
+      return <TextFieldsIcon />;
+    case 'image':
+      return <ImageIcon />;
+    case 'quote':
+      return <FormatQuoteIcon />;
+    default:
+      return <TextFieldsIcon />;
+  }
+};
+
+export const OutlineView: React.FC<OutlineViewProps> = ({
+  slides,
+  onReorder,
+  onSelectSlide,
+  onDeleteSlide,
+  onDuplicateSlide,
+  selectedSlideId,
+}) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = slides.findIndex((slide) => slide.id === active.id);
+      const newIndex = slides.findIndex((slide) => slide.id === over.id);
+      const newSlides = arrayMove(slides, oldIndex, newIndex);
+      onReorder(newSlides);
+    }
+  };
+
+  return (
+    <Paper sx={{ height: '100%', overflow: 'auto', bgcolor: 'background.default' }}>
+      <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}>
+        <Typography variant="h6">Slides</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {slides.length} slide{slides.length !== 1 ? 's' : ''}
+        </Typography>
+      </Box>
+      
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={slides.map(s => s.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <List sx={{ p: 0 }}>
+            {slides.map((slide, index) => (
+              <SortableSlideItem key={slide.id} id={slide.id}>
+                <ListItem
+                  sx={{
+                    borderBottom: 1,
+                    borderColor: 'divider',
+                    bgcolor: selectedSlideId === slide.id ? 'action.selected' : 'transparent',
+                    '&:hover': {
+                      bgcolor: 'action.hover',
+                    },
+                  }}
+                  onClick={() => onSelectSlide(slide.id)}
+                  secondaryAction={
+                    <Box>
+                      <IconButton
+                        edge="end"
+                        aria-label="duplicate"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDuplicateSlide(slide.id);
+                        }}
+                        size="small"
+                      >
+                        <ContentCopyIcon fontSize="small" />
+                      </IconButton>
+                      <IconButton
+                        edge="end"
+                        aria-label="delete"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDeleteSlide(slide.id);
+                        }}
+                        size="small"
+                        sx={{ ml: 1 }}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+                  }
+                >
+                  <ListItemIcon>
+                    {getSlideIcon(slide.type)}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2" noWrap>
+                        {slide.title || `Slide ${index + 1}`}
+                      </Typography>
+                    }
+                    secondary={
+                      <Typography variant="caption" color="text.secondary" noWrap>
+                        {slide.subtitle || slide.type}
+                      </Typography>
+                    }
+                  />
+                </ListItem>
+              </SortableSlideItem>
+            ))}
+          </List>
+        </SortableContext>
+      </DndContext>
+    </Paper>
+  );
+};

--- a/app/components/editor/PresentationEditor.tsx
+++ b/app/components/editor/PresentationEditor.tsx
@@ -1,0 +1,294 @@
+import React, { useState, useCallback } from 'react';
+import {
+  Box,
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Button,
+  Drawer,
+  Divider,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import AddIcon from '@mui/icons-material/Add';
+import SaveIcon from '@mui/icons-material/Save';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { ViewSwitcher, ViewMode } from './ViewSwitcher';
+import { OutlineView } from './OutlineView';
+import { GridView } from './GridView';
+import { DetailView } from './DetailView';
+// Simplified interfaces for the editor
+interface SimpleSlide {
+  id: string;
+  type: string;
+  title?: string;
+  subtitle?: string;
+  content?: string;
+  imageUrl?: string;
+  order: number;
+}
+
+interface SimplifiedPresentation {
+  id: string;
+  title: string;
+  description?: string;
+  userId: string;
+  slides: SimpleSlide[];
+  theme?: any;
+  createdAt?: any;
+  updatedAt?: any;
+}
+
+interface PresentationEditorProps {
+  presentation: SimplifiedPresentation;
+  onSave?: (presentation: SimplifiedPresentation) => void;
+  onPresent?: () => void;
+}
+
+export const PresentationEditor: React.FC<PresentationEditorProps> = ({
+  presentation: initialPresentation,
+  onSave,
+  onPresent,
+}) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.down('md'));
+  
+  const [presentation, setPresentation] = useState(initialPresentation);
+  const [viewMode, setViewMode] = useState<ViewMode>('grid');
+  const [selectedSlideId, setSelectedSlideId] = useState<string | undefined>(
+    presentation.slides[0]?.id
+  );
+  const [drawerOpen, setDrawerOpen] = useState(!isMobile);
+
+  const selectedSlideIndex = presentation.slides.findIndex(
+    (slide) => slide.id === selectedSlideId
+  );
+
+  const handleReorderSlides = useCallback((newSlides: SimpleSlide[]) => {
+    setPresentation((prev) => ({
+      ...prev,
+      slides: newSlides,
+    }));
+  }, []);
+
+  const handleSelectSlide = useCallback((slideId: string) => {
+    setSelectedSlideId(slideId);
+    if (viewMode === 'outline' || viewMode === 'grid') {
+      setViewMode('detail');
+    }
+  }, [viewMode]);
+
+  const handleDeleteSlide = useCallback((slideId: string) => {
+    setPresentation((prev) => {
+      const newSlides = prev.slides.filter((slide) => slide.id !== slideId);
+      if (selectedSlideId === slideId && newSlides.length > 0) {
+        setSelectedSlideId(newSlides[0].id);
+      }
+      return {
+        ...prev,
+        slides: newSlides,
+      };
+    });
+  }, [selectedSlideId]);
+
+  const handleDuplicateSlide = useCallback((slideId: string) => {
+    setPresentation((prev) => {
+      const slideIndex = prev.slides.findIndex((slide) => slide.id === slideId);
+      if (slideIndex === -1) return prev;
+      
+      const originalSlide = prev.slides[slideIndex];
+      const duplicatedSlide: SimpleSlide = {
+        ...originalSlide,
+        id: `${originalSlide.id}-copy-${Date.now()}`,
+        title: `${originalSlide.title} (Copy)`,
+      };
+      
+      const newSlides = [
+        ...prev.slides.slice(0, slideIndex + 1),
+        duplicatedSlide,
+        ...prev.slides.slice(slideIndex + 1),
+      ];
+      
+      return {
+        ...prev,
+        slides: newSlides,
+      };
+    });
+  }, []);
+
+  const handleAddSlide = useCallback(() => {
+    const newSlide: SimpleSlide = {
+      id: `slide-${Date.now()}`,
+      type: 'content',
+      title: 'New Slide',
+      subtitle: '',
+      content: '',
+      order: presentation.slides.length,
+    };
+    
+    setPresentation((prev) => ({
+      ...prev,
+      slides: [...prev.slides, newSlide],
+    }));
+    
+    setSelectedSlideId(newSlide.id);
+    setViewMode('detail');
+  }, [presentation.slides.length]);
+
+  const handleEditSlide = useCallback((slideId: string) => {
+    console.log('Edit slide:', slideId);
+  }, []);
+
+  const handleNavigateSlide = useCallback((index: number) => {
+    if (index >= 0 && index < presentation.slides.length) {
+      setSelectedSlideId(presentation.slides[index].id);
+    }
+  }, [presentation.slides]);
+
+  const handleSave = () => {
+    if (onSave) {
+      onSave(presentation);
+    }
+  };
+
+  const drawerWidth = isTablet ? 280 : 320;
+
+  return (
+    <Box sx={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
+      <AppBar
+        position="fixed"
+        sx={{
+          zIndex: theme.zIndex.drawer + 1,
+          bgcolor: 'background.paper',
+          color: 'text.primary',
+          borderBottom: 1,
+          borderColor: 'divider',
+        }}
+        elevation={0}
+      >
+        <Toolbar>
+          <IconButton
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            onClick={() => setDrawerOpen(!drawerOpen)}
+            sx={{ mr: 2, display: { md: 'none' } }}
+          >
+            <MenuIcon />
+          </IconButton>
+          
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            {presentation.title}
+          </Typography>
+
+          <ViewSwitcher view={viewMode} onChange={setViewMode} />
+
+          <Box sx={{ ml: 2, display: 'flex', gap: 1 }}>
+            <Button
+              startIcon={<AddIcon />}
+              variant="outlined"
+              onClick={handleAddSlide}
+            >
+              Add Slide
+            </Button>
+            {onSave && (
+              <Button
+                startIcon={<SaveIcon />}
+                variant="outlined"
+                onClick={handleSave}
+              >
+                Save
+              </Button>
+            )}
+            {onPresent && (
+              <Button
+                startIcon={<PlayArrowIcon />}
+                variant="contained"
+                onClick={onPresent}
+              >
+                Present
+              </Button>
+            )}
+          </Box>
+        </Toolbar>
+      </AppBar>
+
+      {viewMode === 'outline' && (
+        <Drawer
+          variant={isMobile ? 'temporary' : 'persistent'}
+          open={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+          sx={{
+            width: drawerWidth,
+            flexShrink: 0,
+            '& .MuiDrawer-paper': {
+              width: drawerWidth,
+              boxSizing: 'border-box',
+              mt: '64px',
+            },
+          }}
+        >
+          <OutlineView
+            slides={presentation.slides}
+            onReorder={handleReorderSlides}
+            onSelectSlide={handleSelectSlide}
+            onDeleteSlide={handleDeleteSlide}
+            onDuplicateSlide={handleDuplicateSlide}
+            selectedSlideId={selectedSlideId}
+          />
+        </Drawer>
+      )}
+
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          mt: '64px',
+          ml: viewMode === 'outline' && !isMobile && drawerOpen ? `${drawerWidth}px` : 0,
+          transition: theme.transitions.create(['margin'], {
+            easing: theme.transitions.easing.sharp,
+            duration: theme.transitions.duration.leavingScreen,
+          }),
+          height: 'calc(100vh - 64px)',
+          overflow: 'hidden',
+        }}
+      >
+        {viewMode === 'outline' && !drawerOpen && (
+          <OutlineView
+            slides={presentation.slides}
+            onReorder={handleReorderSlides}
+            onSelectSlide={handleSelectSlide}
+            onDeleteSlide={handleDeleteSlide}
+            onDuplicateSlide={handleDuplicateSlide}
+            selectedSlideId={selectedSlideId}
+          />
+        )}
+        
+        {viewMode === 'grid' && (
+          <GridView
+            slides={presentation.slides}
+            onReorder={handleReorderSlides}
+            onSelectSlide={handleSelectSlide}
+            onDeleteSlide={handleDeleteSlide}
+            onDuplicateSlide={handleDuplicateSlide}
+            selectedSlideId={selectedSlideId}
+          />
+        )}
+        
+        {viewMode === 'detail' && (
+          <DetailView
+            slides={presentation.slides}
+            currentSlideIndex={selectedSlideIndex}
+            onNavigate={handleNavigateSlide}
+            onEditSlide={handleEditSlide}
+            onDeleteSlide={handleDeleteSlide}
+            onDuplicateSlide={handleDuplicateSlide}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/app/components/editor/SortableSlideItem.tsx
+++ b/app/components/editor/SortableSlideItem.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import { Box } from '@mui/material';
+
+interface SortableSlideItemProps {
+  id: string;
+  children: React.ReactNode;
+  showDragHandle?: boolean;
+}
+
+export const SortableSlideItem: React.FC<SortableSlideItemProps> = ({ 
+  id, 
+  children, 
+  showDragHandle = true 
+}) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <Box
+      ref={setNodeRef}
+      style={style}
+      sx={{ 
+        display: 'flex', 
+        alignItems: 'center',
+        cursor: isDragging ? 'grabbing' : 'grab',
+      }}
+    >
+      {showDragHandle && (
+        <Box
+          {...attributes}
+          {...listeners}
+          sx={{ 
+            display: 'flex',
+            alignItems: 'center',
+            p: 1,
+            cursor: 'grab',
+            '&:hover': {
+              color: 'primary.main',
+            },
+          }}
+        >
+          <DragIndicatorIcon />
+        </Box>
+      )}
+      <Box sx={{ flex: 1 }}>
+        {children}
+      </Box>
+    </Box>
+  );
+};

--- a/app/components/editor/ViewSwitcher.tsx
+++ b/app/components/editor/ViewSwitcher.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { ToggleButton, ToggleButtonGroup, Box } from '@mui/material';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+import GridViewIcon from '@mui/icons-material/GridView';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+
+export type ViewMode = 'outline' | 'grid' | 'detail';
+
+interface ViewSwitcherProps {
+  view: ViewMode;
+  onChange: (view: ViewMode) => void;
+}
+
+export const ViewSwitcher: React.FC<ViewSwitcherProps> = ({ view, onChange }) => {
+  const handleChange = (_: React.MouseEvent<HTMLElement>, newView: ViewMode | null) => {
+    if (newView !== null) {
+      onChange(newView);
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <ToggleButtonGroup
+        value={view}
+        exclusive
+        onChange={handleChange}
+        aria-label="view mode"
+        size="small"
+      >
+        <ToggleButton value="outline" aria-label="outline view">
+          <FormatListBulletedIcon sx={{ mr: 1 }} />
+          Outline
+        </ToggleButton>
+        <ToggleButton value="grid" aria-label="grid view">
+          <GridViewIcon sx={{ mr: 1 }} />
+          Grid
+        </ToggleButton>
+        <ToggleButton value="detail" aria-label="detail view">
+          <FullscreenIcon sx={{ mr: 1 }} />
+          Detail
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "phoenix-web",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@firebase/vertexai": "^1.2.4",
@@ -745,6 +748,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "test:ci": "jest --ci --coverage --maxWorkers=2"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@firebase/vertexai": "^1.2.4",

--- a/pages/editor-demo.tsx
+++ b/pages/editor-demo.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { PresentationEditor } from '@/app/components/editor/PresentationEditor';
+import { Presentation } from '@/lib/models/presentation';
+import { Slide, SlideType, TextObject, ImageObject, SlideObjectUnion } from '@/lib/models/slide';
+import { Timestamp } from 'firebase/firestore';
+
+// Simple slide interface for the editor demo
+interface SimpleSlide {
+  id: string;
+  type: string;
+  title?: string;
+  subtitle?: string;
+  content?: string;
+  imageUrl?: string;
+  order: number;
+}
+
+const sampleSlides: SimpleSlide[] = [
+  {
+    id: 'slide-1',
+    type: 'title',
+    title: 'Welcome to Phoenix',
+    subtitle: 'AI-Powered Presentations',
+    content: '',
+    order: 0,
+  },
+  {
+    id: 'slide-2',
+    type: 'content',
+    title: 'Introduction',
+    subtitle: 'About Our Platform',
+    content: 'Phoenix Web is a cutting-edge presentation platform that leverages AI to create stunning presentations in seconds.',
+    order: 1,
+  },
+  {
+    id: 'slide-3',
+    type: 'bullet',
+    title: 'Key Features',
+    subtitle: '',
+    content: JSON.stringify({
+      bullets: [
+        'AI-powered content generation',
+        'Professional design templates',
+        'Real-time collaboration',
+        'Cloud storage and sync',
+        'Export to multiple formats',
+      ],
+    }),
+    order: 2,
+  },
+  {
+    id: 'slide-4',
+    type: 'quote',
+    title: '',
+    subtitle: '',
+    content: JSON.stringify({
+      quote: 'The best way to predict the future is to invent it.',
+      author: 'Alan Kay',
+    }),
+    order: 3,
+  },
+  {
+    id: 'slide-5',
+    type: 'image',
+    title: 'Visual Impact',
+    subtitle: 'Images that speak louder than words',
+    content: '',
+    imageUrl: 'https://images.unsplash.com/photo-1557804506-669a67965ba0?w=1200',
+    order: 4,
+  },
+  {
+    id: 'slide-6',
+    type: 'two-column',
+    title: 'Two Column Layout',
+    subtitle: 'Compare and Contrast',
+    content: JSON.stringify({
+      leftTitle: 'Traditional Presentations',
+      leftContent: 'Time-consuming to create\nLimited design options\nStatic content\nManual updates',
+      rightTitle: 'Phoenix Presentations',
+      rightContent: 'Created in seconds\nAI-powered designs\nDynamic content\nAuto-sync across devices',
+    }),
+    order: 5,
+  },
+  {
+    id: 'slide-7',
+    type: 'content',
+    title: 'Getting Started',
+    subtitle: 'Three Simple Steps',
+    content: '1. Enter your topic or upload content\n2. Choose a design template\n3. Let AI generate your presentation',
+    order: 6,
+  },
+  {
+    id: 'slide-8',
+    type: 'title',
+    title: 'Thank You',
+    subtitle: 'Questions?',
+    content: '',
+    order: 7,
+  },
+];
+
+// Create a demo presentation with simplified slide structure
+const samplePresentation = {
+  id: 'demo-presentation',
+  title: 'Phoenix Web Demo',
+  description: 'A demonstration of the presentation editor capabilities',
+  userId: 'demo-user',
+  slides: sampleSlides,
+  createdAt: Timestamp.now(),
+  updatedAt: Timestamp.now(),
+  theme: {
+    primaryColor: '#1976d2',
+    secondaryColor: '#dc004e',
+    fontFamily: 'Roboto',
+  },
+} as any;
+
+export default function EditorDemo() {
+  const handleSave = (presentation: any) => {
+    console.log('Saving presentation:', presentation);
+    alert('Presentation saved! (Demo mode - not actually saved)');
+  };
+
+  const handlePresent = () => {
+    console.log('Starting presentation mode');
+    alert('Presentation mode would start here');
+  };
+
+  return (
+    <PresentationEditor
+      presentation={samplePresentation}
+      onSave={handleSave}
+      onPresent={handlePresent}
+    />
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,7 @@ import { signInAnonymously } from 'firebase/auth';
 import { auth } from '@/lib/firebase/config';
 import { useAuth } from '@/hooks/useAuth';
 import { Button, Box, Typography, Container, Paper } from '@mui/material';
-import { AutoAwesome, ViewCarousel } from '@mui/icons-material';
+import { AutoAwesome, ViewCarousel, Edit } from '@mui/icons-material';
 import { useRouter } from 'next/router';
 
 export default function Home() {
@@ -67,6 +67,15 @@ export default function Home() {
               disabled={loading || !user}
             >
               My Presentations
+            </Button>
+            
+            <Button
+              variant="outlined"
+              size="large"
+              startIcon={<Edit />}
+              onClick={() => router.push('/editor-demo')}
+            >
+              Editor Demo
             </Button>
           </Box>
           

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,9 +19,23 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- Implemented a comprehensive presentation editor with three distinct viewing modes
- Added drag-and-drop functionality for slide reordering using @dnd-kit library
- Created dynamic grid view with adjustable columns (1-6) via slider control

## Features Implemented

### View Modes
- **Outline View**: Compact list view with slide titles and drag handles
- **Grid View**: Thumbnail grid with dynamic column adjustment (1-6 columns)
- **Detail View**: Full-screen slide preview with navigation controls

### Core Functionality
- ✅ Drag-and-drop reordering in Outline and Grid views
- ✅ Dynamic column slider for Grid view (1-6 columns)
- ✅ Keyboard navigation (arrow keys, F for fullscreen)
- ✅ Slide management (add, duplicate, delete)
- ✅ Responsive design for mobile/tablet devices
- ✅ Fullscreen presentation mode

### Technical Implementation
- Used MUI components throughout (Grid, Slider, ToggleButtonGroup, etc.)
- Integrated @dnd-kit for smooth drag-drop interactions
- Created simplified slide interfaces for editor compatibility
- Maintained TypeScript type safety

## Test Plan
- [x] Navigate to `/editor-demo` to access the presentation editor
- [x] Test view switching between Outline, Grid, and Detail modes
- [x] Verify drag-drop reordering works in Outline view
- [x] Verify drag-drop reordering works in Grid view
- [x] Test column slider adjustment (1-6 columns) in Grid view
- [x] Test keyboard navigation in Detail view (arrow keys)
- [x] Test fullscreen mode (F key) in Detail view
- [x] Verify slide management functions (add, duplicate, delete)
- [x] Test responsive behavior on different screen sizes

## Dependencies Added
- @dnd-kit/core
- @dnd-kit/sortable
- @dnd-kit/utilities

🤖 Generated with [Claude Code](https://claude.ai/code)